### PR TITLE
Conditioned maps for postfix entrypoint

### DIFF
--- a/postfix-entrypoint.sh
+++ b/postfix-entrypoint.sh
@@ -15,6 +15,8 @@ for file in /data/postfix_maps/*; do
 done
 
 # Map all files in Postfix configuration directory
-postmap /etc/postfix/*
+for file in /etc/postfix/*; do
+    [ ! $file == /etc/postfix/postfix-files ] && [[ ! $file =~ cf ]] && [[ ! $file =~ \.db$ ]] && [ ! -d $file ] && postmap $file && echo "Mapping file $file"
+done
 
 exec /usr/sbin/postfix -c /etc/postfix start


### PR DESCRIPTION
Only necessary files are mapped to avoid failures when starting the service and make sure the dbs are complete when starting the service.