### PR TITLE
Add support for changing default nameserver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ LABEL version=${VERSION}
 LABEL description="Alpine based postfix/dnsmasq/imap image."
 LABEL maintainer="devs@evicertia.com"
 
+COPY ./main.sh .
 COPY ./*.sh  /usr/sbin/
 COPY ./*.ini  /etc/supervisor.d/
 
@@ -20,4 +21,4 @@ EXPOSE 53/udp
 EXPOSE 143/tcp
 EXPOSE 25/tcp
 
-ENTRYPOINT [ "supervisord", "-n", "-e", "debug", "-c", "/etc/supervisord.conf" ]
+ENTRYPOINT [ "/main.sh" ]

--- a/main.sh
+++ b/main.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+SUPERVISORPATH="/usr/bin/supervisord"
+
+# Map DNS server
+if [ -n "${DNSSERVER}" ]
+then \
+	echo "Setting DNS server to ${DNSSERVER}"
+	if ! [[ "${DNSSERVER}" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+		DNSSERVER=$(getent hosts "${DNSSERVER}" | awk '{ print $1 }')
+		[ -z "${DNSSERVER}" ] && print_error "Unable to resolve DNSSERVER address." && exit 254
+	fi
+	TMPFILE=$(mktemp /tmp/resolv.XXXXXX)
+	sed -e '/^nameserver .*/d' /etc/resolv.conf > ${TMPFILE}
+	echo "nameserver ${DNSSERVER}" >> ${TMPFILE}
+	cat ${TMPFILE} > /etc/resolv.conf
+fi
+
+exec ${SUPERVISORPATH} -n -e debug -c /etc/supervisord.conf


### PR DESCRIPTION
Added a main.sh that allows changing default nameserver in resolv.conf file at startup, in case an env variable is set with the host/address of the desired nameserver.