### PR TITLE
Remove version tag for Postfix in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY ./main.sh .
 COPY ./*.sh  /usr/sbin/
 COPY ./*.ini  /etc/supervisor.d/
 
-RUN apk add --no-cache postfix=3.5.2-r1 bash busybox-extras imap dnsmasq supervisor
+RUN apk add --no-cache postfix bash busybox-extras imap dnsmasq supervisor
 
 
 VOLUME /data


### PR DESCRIPTION
Postfix no longer needs a specific version as alpine has included a newer one in its repos. Therefore, the version tag has been deleted in Dockerfile.